### PR TITLE
Configure Dependabot for pip, npm, and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: 'pip' # See documentation for possible values
+    directory: '/' # Location of package manifests
+    schedule:
+      interval: 'monthly'
+    assignees:
+      - 'ttsukagoshi'
+    target-branch: 'main'
+    open-pull-requests-limit: 10
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    assignees:
+      - 'ttsukagoshi'
+    target-branch: 'main'
+    open-pull-requests-limit: 10
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'monthly'
+    assignees:
+      - 'ttsukagoshi'
+    target-branch: 'main'
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This pull request introduces automated dependency update management for the repository by adding a `.github/dependabot.yml` configuration file. This enables Dependabot to regularly check for and propose updates to dependencies across multiple ecosystems.

Dependabot configuration:

* Added `.github/dependabot.yml` to enable automated dependency updates for `pip`, `npm`, and `github-actions` package ecosystems, with a monthly update schedule and pull requests assigned to `ttsukagoshi`.