### PR TITLE
Update checkout action version ref from `v5` to `v5.0.0` for stability

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v5.0.0
         with:
           # super-linter needs the full git history to get the
           # list of files that changed across commits


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration by specifying the full semantic version for the `actions/checkout` step in `.github/workflows/super-linter.yml`. This ensures that the workflow uses `v5.0.0` of the action, which can help with version consistency and reliability.