### PR TITLE
Improve file writing consistency and subprocess invocation between multiple OS platforms in `poetry run build`

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -102,7 +102,7 @@ def generate_tableau_preferences(palettes: List[Dict[str, Any]], output_path: st
     lines.extend(["  </preferences>", "</workbook>"])
 
     # Write to file
-    with open(output_path, "w", encoding="utf-8") as file:
+    with open(output_path, "w", encoding="utf-8", newline="\n") as file:
         file.write("\n".join(lines) + "\n")
 
 
@@ -175,7 +175,7 @@ def generate_r_script(palettes: List[Dict[str, Any]], output_path: str):
         lines.append("")  # Add blank line between palettes
 
     # Write to file
-    with open(output_path, "w", encoding="utf-8") as file:
+    with open(output_path, "w", encoding="utf-8", newline="\n") as file:
         file.write("\n".join(lines))
 
 


### PR DESCRIPTION
This pull request makes minor improvements to the `scripts/build.py` file, focusing on file writing consistency and subprocess invocation reliability.

File writing improvements:
* Ensured that files generated by `generate_tableau_preferences` and `generate_r_script` use Unix-style line endings by specifying `newline="\n"` in the `open` function. [[1]](diffhunk://#diff-c786cc346fc8fdc17f1c85f11bc187c153a3511ae549390185c7c39343d2c95dL105-R105) [[2]](diffhunk://#diff-c786cc346fc8fdc17f1c85f11bc187c153a3511ae549390185c7c39343d2c95dL178-R178)

Subprocess invocation:
* Added `shell=True` to the `subprocess.run` call in `run_prettier` to improve compatibility with shell commands.