### PR TITLE
Update palette: Exam types

### DIFF
--- a/palettes.yml
+++ b/palettes.yml
@@ -37,9 +37,9 @@ palettes:
         value: '#ffbeb2'
       - key: 'AP'
         value: '#4e79a7'
-  - name: 'AIU Exam Types'
+  - name: 'AIU Abbreviated Exam Types'
     type: 'categorical'
-    description: 'Colors for the exam types at AIU'
+    description: 'Colors for the abbreviated exam types at AIU'
     colors:
       - key: 'A'
         value: '#2a5783'
@@ -47,10 +47,26 @@ palettes:
         value: '#5b8cb8'
       - key: 'C'
         value: '#b9ddf1'
-      - key: 'GS'
+      - key: 'GS' # グローバル・セミナー入試
         value: '#24693d'
-      - key: 'GW'
+      - key: 'GW' # グローバル・ワークショップ入試
         value: '#b3e0a6'
+      - key: 'Sougou' # 総合選抜型入試
+        value: '#9e3d22'
+      - key: 'Recommendation' # 学校推薦型入試
+        value: '#e36420'
+      - key: 'International' # 外国人留学生入試
+        value: '#f59c3c'
+      - key: 'Gap' # ギャップイヤー入試
+        value: '#ffc685'
+      - key: 'Other Undergrad Exams' # その他の学部入試 e.g., 社会人入試、帰国生入試
+        value: '#9f3632'
+      - key: 'Transfer (2nd yr) Sp. Non Degree' # 編入学 (2年次特科)
+        value: '#59504e'
+      - key: 'Transfer (2nd yr)' # 編入学 (2年次)
+        value: '#948c88'
+      - key: 'Transfer (Others)' # 編入学 (その他)
+        value: '#dcd4d0'
   - name: 'AIU In-School Semesters'
     type: 'categorical'
     description: 'Colors for the in-school semesters at AIU'
@@ -120,9 +136,9 @@ palettes:
   - name: 'AIU Exchange Region'
     type: 'categorical'
     description: >
-      Colors for regions for inbound exchange student origin or 
+      Colors for regions for inbound exchange student origin or
       outbound student destination at AIU
-    credits: >
+    credit: >
       Derived from "PowerBI Default" Tableau palette by Ken Flerlage 
       available at https://public.tableau.com/app/profile/ken.flerlage/viz/DatafamColors/
     colors:

--- a/r_script/ir_color_palettes.R
+++ b/r_script/ir_color_palettes.R
@@ -22,14 +22,22 @@ color_values_aiu_grades <- c(
     "AP" = "#4e79a7"
 )
 
-color_values_aiu_exam_types <- c(
+color_values_aiu_abbreviated_exam_types <- c(
     # Type: Categorical
-    # Description: Colors for the exam types at AIU
+    # Description: Colors for the abbreviated exam types at AIU
     "A" = "#2a5783",
     "B" = "#5b8cb8",
     "C" = "#b9ddf1",
     "GS" = "#24693d",
-    "GW" = "#b3e0a6"
+    "GW" = "#b3e0a6",
+    "Sougou" = "#9e3d22",
+    "Recommendation" = "#e36420",
+    "International" = "#f59c3c",
+    "Gap" = "#ffc685",
+    "Other Undergrad Exams" = "#9f3632",
+    "Transfer (2nd yr) Sp. Non Degree" = "#59504e",
+    "Transfer (2nd yr)" = "#948c88",
+    "Transfer (Others)" = "#dcd4d0"
 )
 
 color_values_aiu_inschool_semesters <- c(

--- a/tableau/Preferences.tps
+++ b/tableau/Preferences.tps
@@ -37,8 +37,8 @@
       <!-- AP -->
       <color>#4e79a7</color>
     </color-palette>
-    <color-palette name="AIU Exam Types" type="regular">
-      <!-- Colors for the exam types at AIU -->
+    <color-palette name="AIU Abbreviated Exam Types" type="regular">
+      <!-- Colors for the abbreviated exam types at AIU -->
       <!-- A -->
       <color>#2a5783</color>
       <!-- B -->
@@ -49,6 +49,22 @@
       <color>#24693d</color>
       <!-- GW -->
       <color>#b3e0a6</color>
+      <!-- Sougou -->
+      <color>#9e3d22</color>
+      <!-- Recommendation -->
+      <color>#e36420</color>
+      <!-- International -->
+      <color>#f59c3c</color>
+      <!-- Gap -->
+      <color>#ffc685</color>
+      <!-- Other Undergrad Exams -->
+      <color>#9f3632</color>
+      <!-- Transfer (2nd yr) Sp. Non Degree -->
+      <color>#59504e</color>
+      <!-- Transfer (2nd yr) -->
+      <color>#948c88</color>
+      <!-- Transfer (Others) -->
+      <color>#dcd4d0</color>
     </color-palette>
     <color-palette name="AIU In-School Semesters" type="regular">
       <!-- Colors for the in-school semesters at AIU -->
@@ -111,7 +127,7 @@
       <color>#2a5783</color>
     </color-palette>
     <color-palette name="AIU Exchange Region" type="regular">
-      <!-- Colors for regions for inbound exchange student origin or  outbound student destination at AIU
+      <!-- Colors for regions for inbound exchange student origin or outbound student destination at AIU
  -->
       <!-- North America -->
       <color>#3599b8</color>


### PR DESCRIPTION
This PR is part of addressing issue #30 

---

This pull request updates the color palettes for AIU exam types across multiple configuration files to expand the set of exam types and clarify their naming. The changes ensure consistency between the YAML, R, and Tableau files, and add several new abbreviated exam types with corresponding colors.

**Palette expansion and naming updates:**

* Renamed `AIU Exam Types` to `AIU Abbreviated Exam Types` and updated descriptions in `palettes.yml`, `r_script/ir_color_palettes.R`, and `tableau/Preferences.tps` for clarity and consistency. [[1]](diffhunk://#diff-04d68014aca64a81cb20b4b37b454888b10392e2cfffac1081f4bcc964c60b19L40-R69) [[2]](diffhunk://#diff-aca6144d1885ec4bbd0aaa7ddbc70bc452290a5e4f81ccdba15fb38957622d63L25-R40) [[3]](diffhunk://#diff-ed90c290eaf51888cc078cacebed220aa191044edf034c4ddda109150cbf6a5aL40-R41)
* Added new abbreviated exam types (`Sougou`, `Recommendation`, `International`, `Gap`, `Other Undergrad Exams`, `Transfer (2nd yr) Sp. Non Degree`, `Transfer (2nd yr)`, `Transfer (Others)`) with distinct color values in all relevant files. [[1]](diffhunk://#diff-04d68014aca64a81cb20b4b37b454888b10392e2cfffac1081f4bcc964c60b19L40-R69) [[2]](diffhunk://#diff-aca6144d1885ec4bbd0aaa7ddbc70bc452290a5e4f81ccdba15fb38957622d63L25-R40) [[3]](diffhunk://#diff-ed90c290eaf51888cc078cacebed220aa191044edf034c4ddda109150cbf6a5aR52-R67)

**Minor metadata correction:**

* Fixed a typo in the region palette metadata in `palettes.yml` by changing `credits` to `credit`.