### PR TITLE
Add palettes: Student status & EAP level at enrollment

### DIFF
--- a/palettes.yml
+++ b/palettes.yml
@@ -67,11 +67,43 @@ palettes:
         value: '#948c88'
       - key: 'Transfer (Others)' # 編入学 (その他)
         value: '#dcd4d0'
+  - name: 'AIU Student Status'
+    type: 'categorical'
+    description: 'Colors for the student status (現況区分) at AIU'
+    colors:
+      - key: 'In School' # 通常
+        value: '#4e7fac'
+      - key: 'On leave' # 休学
+        value: '#ffc685'
+      - key: 'Graduated' # 卒業
+        value: '#24693d'
+      - key: 'Completed' # 修了
+        value: '#59a253'
+      - key: 'Withdrawn' # 退学
+        value: '#9f3632'
+      - key: 'Expelled' # 除籍
+        value: '#49525e'
+  - name: 'AIU EAP Level at Enrollment'
+    type: 'categorical'
+    description: 'Colors for the EAP level at enrollment for undergraduate students at AIU'
+    credit: >
+      Derived primarily from the built-in "Green-Gold" palette in Tableau
+    colors:
+      - key: 'EAP I'
+        value: '#f4d166'
+      - key: 'EAP II'
+        value: '#a7bf5a'
+      - key: 'EAP III'
+        value: '#60a656'
+      - key: 'EAP Bridge'
+        value: '#39894c'
+      - key: 'NA'
+        value: '#49525e'
   - name: 'AIU In-School Semesters'
     type: 'categorical'
     description: 'Colors for the in-school semesters at AIU'
     credit: >
-      Derived primarily from built-in "Hue Circle" palette in Tableau
+      Derived primarily from the built-in "Hue Circle" palette in Tableau
     colors:
       - key: '0'
         value: '#1ba3c6'

--- a/r_script/ir_color_palettes.R
+++ b/r_script/ir_color_palettes.R
@@ -40,6 +40,27 @@ color_values_aiu_abbreviated_exam_types <- c(
     "Transfer (Others)" = "#dcd4d0"
 )
 
+color_values_aiu_student_status <- c(
+    # Type: Categorical
+    # Description: Colors for the student status (現況区分) at AIU
+    "In School" = "#4e7fac",
+    "On leave" = "#ffc685",
+    "Graduated" = "#24693d",
+    "Completed" = "#59a253",
+    "Withdrawn" = "#9f3632",
+    "Expelled" = "#49525e"
+)
+
+color_values_aiu_eap_level_at_enrollment <- c(
+    # Type: Categorical
+    # Description: Colors for the EAP level at enrollment for undergraduate students at AIU
+    "EAP I" = "#f4d166",
+    "EAP II" = "#a7bf5a",
+    "EAP III" = "#60a656",
+    "EAP Bridge" = "#39894c",
+    "NA" = "#49525e"
+)
+
 color_values_aiu_inschool_semesters <- c(
     # Type: Categorical
     # Description: Colors for the in-school semesters at AIU

--- a/tableau/Preferences.tps
+++ b/tableau/Preferences.tps
@@ -66,6 +66,34 @@
       <!-- Transfer (Others) -->
       <color>#dcd4d0</color>
     </color-palette>
+    <color-palette name="AIU Student Status" type="regular">
+      <!-- Colors for the student status (現況区分) at AIU -->
+      <!-- In School -->
+      <color>#4e7fac</color>
+      <!-- On leave -->
+      <color>#ffc685</color>
+      <!-- Graduated -->
+      <color>#24693d</color>
+      <!-- Completed -->
+      <color>#59a253</color>
+      <!-- Withdrawn -->
+      <color>#9f3632</color>
+      <!-- Expelled -->
+      <color>#49525e</color>
+    </color-palette>
+    <color-palette name="AIU EAP Level at Enrollment" type="regular">
+      <!-- Colors for the EAP level at enrollment for undergraduate students at AIU -->
+      <!-- EAP I -->
+      <color>#f4d166</color>
+      <!-- EAP II -->
+      <color>#a7bf5a</color>
+      <!-- EAP III -->
+      <color>#60a656</color>
+      <!-- EAP Bridge -->
+      <color>#39894c</color>
+      <!-- NA -->
+      <color>#49525e</color>
+    </color-palette>
     <color-palette name="AIU In-School Semesters" type="regular">
       <!-- Colors for the in-school semesters at AIU -->
       <!-- 0 -->


### PR DESCRIPTION
This PR is part of resolving issue #30 

---

This pull request introduces two new categorical color palettes for AIU-related data across the codebase and configuration files. These palettes cover student status and EAP level at enrollment, ensuring consistent color usage in R scripts, Tableau visualizations, and YAML palette definitions.

**New AIU-specific color palettes:**

* **Student Status Palette**
  - Added color mappings for various student statuses (e.g., In School, On leave, Graduated, Completed, Withdrawn, Expelled) to `palettes.yml`, `r_script/ir_color_palettes.R`, and `tableau/Preferences.tps`. [[1]](diffhunk://#diff-04d68014aca64a81cb20b4b37b454888b10392e2cfffac1081f4bcc964c60b19R70-R106) [[2]](diffhunk://#diff-aca6144d1885ec4bbd0aaa7ddbc70bc452290a5e4f81ccdba15fb38957622d63R43-R63) [[3]](diffhunk://#diff-ed90c290eaf51888cc078cacebed220aa191044edf034c4ddda109150cbf6a5aR69-R96)

* **EAP Level at Enrollment Palette**
  - Added color mappings for EAP levels at enrollment (EAP I, EAP II, EAP III, EAP Bridge, NA) to `palettes.yml`, `r_script/ir_color_palettes.R`, and `tableau/Preferences.tps`. [[1]](diffhunk://#diff-04d68014aca64a81cb20b4b37b454888b10392e2cfffac1081f4bcc964c60b19R70-R106) [[2]](diffhunk://#diff-aca6144d1885ec4bbd0aaa7ddbc70bc452290a5e4f81ccdba15fb38957622d63R43-R63) [[3]](diffhunk://#diff-ed90c290eaf51888cc078cacebed220aa191044edf034c4ddda109150cbf6a5aR69-R96)

**Documentation and consistency improvements:**

* Updated palette descriptions and credits for clarity and consistency in `palettes.yml`.