### PR TITLE
Rename palette: 'Outbound Student Affiliation' to 'Program Affiliation'

### DIFF
--- a/palettes.yml
+++ b/palettes.yml
@@ -83,10 +83,10 @@ palettes:
         value: '#9f3632'
       - key: 'Expelled' # 除籍
         value: '#49525e'
-  - name: 'AIU Outbound Student Affiliation'
+  - name: 'AIU Program Affiliation'
     type: 'categorical'
     description: >
-      Colors for affiliations types for students going outbound at AIU
+      Colors for program affiliations for students, courses, and faculty members at AIU
     credit: >
       Derived from built-in "Automatic" palette in Tableau
     colors:

--- a/r_script/ir_color_palettes.R
+++ b/r_script/ir_color_palettes.R
@@ -51,9 +51,9 @@ color_values_aiu_student_status <- c(
     "Expelled" = "#49525e"
 )
 
-color_values_aiu_outbound_student_affiliation <- c(
+color_values_aiu_program_affiliation <- c(
     # Type: Categorical
-    # Description: Colors for affiliations types for students going outbound at AIU
+    # Description: Colors for program affiliations for students, courses, and faculty members at AIU
 
     "GB" = "#4e79a7",
     "GS" = "#f28e2b",

--- a/tableau/Preferences.tps
+++ b/tableau/Preferences.tps
@@ -81,8 +81,8 @@
       <!-- Expelled -->
       <color>#49525e</color>
     </color-palette>
-    <color-palette name="AIU Outbound Student Affiliation" type="regular">
-      <!-- Colors for affiliations types for students going outbound at AIU
+    <color-palette name="AIU Program Affiliation" type="regular">
+      <!-- Colors for program affiliations for students, courses, and faculty members at AIU
  -->
       <!-- GB -->
       <color>#4e79a7</color>


### PR DESCRIPTION
This PR is part of resolving issue #30 

---

This pull request updates the color palette definitions for AIU program affiliations by introducing a new "AIU Program Affiliation" palette and removing the older "AIU Outbound Student Affiliation" palette. The changes ensure consistency across the YAML, R script, and Tableau preferences files, aligning the color assignments for program affiliations for students, courses, and faculty members.

**Palette updates and standardization:**

* Added a new `AIU Program Affiliation` palette with categorical colors for `GB`, `GS`, and `GC` in `palettes.yml`, `r_script/ir_color_palettes.R`, and `tableau/Preferences.tps`. This palette is derived from Tableau's "Automatic" palette and intended for program affiliations. [[1]](diffhunk://#diff-04d68014aca64a81cb20b4b37b454888b10392e2cfffac1081f4bcc964c60b19R86-R98) [[2]](diffhunk://#diff-aca6144d1885ec4bbd0aaa7ddbc70bc452290a5e4f81ccdba15fb38957622d63R54-R62) [[3]](diffhunk://#diff-ed90c290eaf51888cc078cacebed220aa191044edf034c4ddda109150cbf6a5aR84-R93)
* Removed the old `AIU Outbound Student Affiliation` palette and its associated color definitions from `palettes.yml`, `r_script/ir_color_palettes.R`, and `tableau/Preferences.tps` to avoid duplication and maintain clarity. [[1]](diffhunk://#diff-04d68014aca64a81cb20b4b37b454888b10392e2cfffac1081f4bcc964c60b19L255-L267) [[2]](diffhunk://#diff-aca6144d1885ec4bbd0aaa7ddbc70bc452290a5e4f81ccdba15fb38957622d63L155-L163) [[3]](diffhunk://#diff-ed90c290eaf51888cc078cacebed220aa191044edf034c4ddda109150cbf6a5aL233-L242)