### PR TITLE
Add version management script to be run with `poetry run`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,9 @@ packages = [
 formatter = "scripts.formatter:main"
 linter = "scripts.linter:main"
 build = "scripts.build:main"
+version_major = "scripts.version:major"
+version_minor = "scripts.version:minor"
+version_patch = "scripts.version:patch"
 
 [tool.isort]
 profile = "black"

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,5 @@
+"""
+Scripts module for ir-color-guide package.
+"""
+
+__version__ = "0.0.1"  # Version number. Do NOT update manually!

--- a/scripts/version.py
+++ b/scripts/version.py
@@ -1,0 +1,178 @@
+"""
+Script for version management like Node.js's `npm version [major|minor|patch]`.
+It updates the `version` in pyproject.toml according to semantic versioning,
+commits the change to git, and tags it with `vX.Y.Z`.
+By defining it in pyproject.toml's [tool.poetry.scripts],
+it can be run as `poetry run version_[major|minor|patch]`.
+"""
+
+import subprocess
+
+
+def get_version() -> str:
+    """
+    Get the `version` from pyproject.toml.
+
+    Returns:
+        str: a version number in X.Y.Z format according to Semantic Versioning,
+            without a leading `v` (e.g., 1.2.3).
+    """
+    result = subprocess.run(
+        ["poetry", "version"], check=True, text=True, stdout=subprocess.PIPE
+    )
+    return result.stdout.split(" ")[1].strip()
+
+
+def get_branch() -> str:
+    """Get the current Git branch name."""
+    result = subprocess.run(
+        ["git", "branch", "--show-current"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    return result.stdout.strip()
+
+
+def update_init_py_version(current_version: str, new_version: str) -> None:
+    """
+    Update the __version__ in scripts/__init__.py.
+
+    Args:
+        current_version (str):
+            Current version number in X.Y.Z format according to Semantic Versioning,
+            without a leading `v` (e.g., 1.2.3).
+        new_version (str):
+            New version number in X.Y.Z format according to Semantic Versioning,
+            without a leading `v` (e.g., 1.2.3).
+    """
+    # Read the entire __init__.py and replace only the __version__ line
+    with open("scripts/__init__.py", "r", encoding="utf-8") as fread:
+        script_text = fread.read()
+    with open("scripts/__init__.py", "w", encoding="utf-8", newline="\n") as fwrite:
+        script_text = script_text.replace(
+            f'__version__ = "{current_version}"', f'__version__ = "{new_version}"'
+        )
+        fwrite.write(script_text)
+
+
+def git_add_commit_version_tag(new_version: str) -> None:
+    """
+    Commit the version update by running git add and git commit.
+
+    Args:
+        new_version (str):
+            New version number in X.Y.Z format according to Semantic Versioning,
+            without a leading `v` (e.g., 1.2.3).
+    """
+    # Commit the version update
+    subprocess.run(["git", "add", "scripts/__init__.py"], check=True)
+    subprocess.run(["git", "add", "pyproject.toml"], check=True)
+    subprocess.run(
+        ["git", "commit", "-m", f"Bump version to {new_version}"], check=True
+    )
+    # Tag the new version
+    subprocess.run(["git", "tag", f"v{new_version}"], check=True)
+
+
+def is_clean_main_branch() -> bool:
+    """
+    Return True if the current Git branch is 'main'
+    and there are no uncommitted or unpushed changes.
+    Return False otherwise.
+
+    Returns:
+        bool: True if on clean 'main' branch, False otherwise.
+    """
+    result = subprocess.run(
+        ["git", "status", "--porcelain", "--branch"],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    lines = result.stdout.strip().split("\n")
+    if len(lines) == 1 and lines[0] == "## main...origin/main":
+        return True
+    return False
+
+
+def check_branch() -> None:
+    """
+    Checks that the current Git branch is 'main'
+    and that there are no uncommitted or unpushed changes.
+
+    Raises:
+        RuntimeError: if the current branch is not 'main'
+                      or if there are uncommitted or unpushed changes.
+    """
+    current_branch = get_branch()
+    if not current_branch == "main":
+        raise RuntimeError(
+            f"The current Git branch is not 'main': {current_branch}\n"
+            "Please switch to the 'main' branch before running this.\n"
+            "Aborting version bump."
+        )
+    if not is_clean_main_branch():
+        raise RuntimeError(
+            "There are uncommitted or unpushed changes.\n"
+            "Please ensure the 'main' branch is clean before running this.\n"
+            "Aborting version bump."
+        )
+
+
+def bump_version(version_type: str) -> None:
+    """
+    Update the `version` in pyproject.toml according to semantic versioning,
+    commit the changes to git, and tag the commit with `vX.Y.Z`.
+
+    Args:
+        version_type (str): "major", "minor", or "patch"
+    Raises:
+        ValueError: if version_type is not one of "major", "minor", or "patch"
+    """
+    if version_type not in ["major", "minor", "patch"]:
+        raise ValueError("version_type must be 'major', 'minor', or 'patch'")
+    # Check that the current Git branch is 'main' and there are no uncommitted or unpushed changes
+    check_branch()
+    # Get the current version
+    current_version = get_version()
+    # Update the version in pyproject.toml
+    subprocess.run(["poetry", "version", version_type], check=True)
+    # Get the updated version
+    new_version = get_version()
+    # Update __version__ in scripts/__init__.py
+    update_init_py_version(current_version, new_version)
+    # Commit and tag the version update
+    git_add_commit_version_tag(new_version)
+    # Completion message
+    message = (
+        f"Bumped version to {new_version}.\n"
+        "Don't forget to push the changes and the tag to the remote repository by running:\n\n"
+        "\tgit push\n"
+        "\tgit push --tags"
+    )
+    print(message)
+
+
+def major():
+    """
+    Major version bump. Apply when there are backward-incompatible changes.
+    Example: v1.1.0 -> v2.0.0
+    """
+    bump_version("major")
+
+
+def minor():
+    """
+    Minor version bump. Apply when there are backward-compatible new features.
+    Example: v1.1.0 -> v1.2.0
+    """
+    bump_version("minor")
+
+
+def patch():
+    """
+    Patch version bump. Apply when there are backward-compatible bug fixes or minor changes.
+    Example: v1.1.0 -> v1.1.1
+    """
+    bump_version("patch")


### PR DESCRIPTION
Resolve #43

---

This pull request introduces a version management system for the project, similar to Node.js's `npm version`, allowing maintainers to bump the major, minor, or patch version using Poetry scripts. It also adds a `__version__` attribute to the `scripts` package for internal version tracking. The most significant changes are grouped below:

**Version Management Automation:**

* Added a new `scripts/version.py` module that provides functions to bump the project version (major, minor, patch), update the version in both `pyproject.toml` and `scripts/__init__.py`, commit these changes, and tag the commit in git. The script ensures version bumps only occur on a clean `main` branch.
* Registered three new Poetry scripts in `pyproject.toml`—`version_major`, `version_minor`, and `version_patch`—to run the corresponding version bump commands via `poetry run`.

**Version Tracking:**

* Added a `__version__` attribute to `scripts/__init__.py` to keep the package version in sync and easily accessible from within Python.