### PR TITLE
Update SECURITY.md for consistent formatting and improved clarification

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -2,25 +2,26 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in the `IR Data Visualization Color Guidelines` project, please report it responsibly. 
+If you discover a security vulnerability in this project, please report it responsibly.
 
-- **Email**: [ir.div@aiu.ac.jp](mailto:ir.div@aiu.ac.jp)  
-- **PGP key for encrypted disclosure**: PGP key information to be updated (if applicable)
+- **Email**: [ir.div@aiu.ac.jp](mailto:ir.div@aiu.ac.jp)
 
-Please do not use GitHub issues or discussions to report security vulnerabilities.
+> [!IMPORTANT]
+> Please do not use GitHub issues or discussions to report security vulnerabilities.
 
 ### What to Include in Your Report
+
 To help us understand and mitigate the issue quickly, please include the following in your initial report:
+
 - A description of the vulnerability, including its impact
 - The steps required to reproduce the vulnerability, if possible
 - Any relevant proof-of-concept code, exploit tools, or configurations
+- Your contact information for follow-up questions
+- Your public profile or website, if you would like to be credited
 
 ## Supported Versions
 
-| Version         | Supported          |
-|-----------------|--------------------|
-| Latest release  | ✅                 |
-| Older versions  | ❌                 |
+We actively maintain and provide security updates for only the latest version of this project.
 
 ## Response Time
 
@@ -33,7 +34,8 @@ We appreciate clear instructions when submitting reports on disclosure timelines
 ## Rules for Testing
 
 When testing vulnerabilities, please adhere to the following guidelines:
+
 - Do NOT test in production environments
 - Avoid any actions that compromise data integrity, privacy, or availability for users
 
-Thank you for helping improve the security of the `IR Data Visualization Color Guidelines` project. The security of our users and contributors is extremely important!
+Thank you for helping improve the security of this project. The security of our users and contributors is extremely important!


### PR DESCRIPTION
Resolve #36 

> [!NOTE] 
> `.github/SECURITY.md` was already created in https://github.com/akita-international-university/ir-color-guide/commit/531e66e2768ff26404a305319fa0615b0d58303e by @ttsukagoshi and copilot, but missed reference to #36

---

This pull request updates the project's security policy documentation to provide clearer and more general guidance for reporting vulnerabilities and testing. The changes modernize the language, clarify instructions, and update the supported versions section.

Documentation improvements:

* Updated the vulnerability reporting instructions to use more general project references instead of the previous project-specific name, and clarified not to use GitHub issues or discussions for reporting. Added an "IMPORTANT" callout for emphasis.
* Expanded the list of information to include in vulnerability reports, adding contact information and an optional public profile for credit.
* Revised the supported versions section to state that only the latest version receives security updates, replacing the previous table format.
* Updated the rules for testing vulnerabilities to use general project references and clarified the language.