### PR TITLE
Remove run_prettier function and update tests to use subprocess for formatting

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -178,36 +178,6 @@ def generate_r_script(palettes: List[Dict[str, Any]], output_path: str):
         file.write("\n".join(lines))
 
 
-def run_prettier(file_path: str):
-    """
-    Run Prettier on the specified file.
-
-    Note:
-        This function requires Node.js and npm to be installed and available in PATH.
-        Prettier is run via npx, which should be available with npm 5.2+.
-
-    Args:
-        file_path: Path to the file to format
-
-    Raises:
-        subprocess.CalledProcessError: If Prettier fails to run
-        FileNotFoundError: If npx/prettier is not installed
-    """
-    print(f"Running Prettier on {file_path}...")
-    try:
-        subprocess.run(
-            ["npx", "prettier", file_path, "--write"],
-            check=True,
-            capture_output=True,
-            text=True,
-            shell=True,
-        )
-    except subprocess.CalledProcessError as e:
-        print(f"Prettier failed for {file_path}.\nError output:\n{e.stderr}")
-        raise
-    print(f"Prettier formatting done for {file_path}.")
-
-
 def main():
     """
     Main function to convert palettes.yml to Tableau and R files.
@@ -233,12 +203,12 @@ def main():
     generate_tableau_preferences(palettes, tableau_path)
     print("Tableau Preferences file generated.")
 
-    # Run Prettier on Tableau file
-    run_prettier(tableau_path)
-
     # Generate R script file
     print(f"Generating R script file at {r_script_path}...")
     generate_r_script(palettes, r_script_path)
     print("R script file generated.")
+
+    # Run formatters
+    subprocess.run(["poetry", "run", "formatter"], check=True)
 
     print("All files generated successfully.")


### PR DESCRIPTION
Resolve #68

---

This pull request refactors how code formatting is handled in the build script and its associated tests. The main change is the removal of the custom `run_prettier` function in favor of using a standardized formatter command via Poetry, which simplifies maintenance and improves consistency. Related tests have been updated to reflect this change.

**Build script changes:**

* Removed the custom `run_prettier` function from `scripts/build.py`, eliminating direct calls to Prettier and its subprocess logic.
* Updated the `main()` function in `scripts/build.py` to run the formatter using `subprocess.run(["poetry", "run", "formatter"], check=True)` instead of calling `run_prettier`.

**Test suite updates:**

* Removed all tests for the `run_prettier` function from `tests/test_build.py`, since the function no longer exists.
* Updated tests for the `main()` function in `tests/test_build.py` to mock and assert calls to `subprocess.run` for the formatter, instead of `run_prettier`. [[1]](diffhunk://#diff-e7bc8c7d1837f65155df89f3b2662ca449b5800ee5d6b6b656c3564cb50d3e82L453-R410) [[2]](diffhunk://#diff-e7bc8c7d1837f65155df89f3b2662ca449b5800ee5d6b6b656c3564cb50d3e82L468-R430) [[3]](diffhunk://#diff-e7bc8c7d1837f65155df89f3b2662ca449b5800ee5d6b6b656c3564cb50d3e82L499-R458)
* Cleaned up imports in `tests/test_build.py` by removing unused imports related to subprocess.