### PR TITLE
Add YAML front matter to python-scripts.instructions.md

### DIFF
--- a/.github/instructions/python-scripts.instructions.md
+++ b/.github/instructions/python-scripts.instructions.md
@@ -1,3 +1,7 @@
+---
+applyTo: '**/scripts/**/*.py'
+---
+
 # Code Review Instructions for Python Scripts
 
 This file provides instructions for GitHub Copilot code review when reviewing changes to Python script files in the `scripts/` directory.


### PR DESCRIPTION
To specify the target files to which this path-specific instructions file should be applied.

---

This pull request adds a configuration file to define code review instructions for Python scripts under the `scripts/` directory. This helps standardize review processes for these files.

- Documentation and configuration:
  * Added `.github/instructions/python-scripts.instructions.md` to specify Copilot code review instructions for all Python files in `scripts/` subdirectories.