### PR TITLE
Update Dependabot settings on schedule & grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,30 +8,39 @@ updates:
   - package-ecosystem: 'pip' # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     cooldown:
       default-days: 7
     assignees:
       - 'ttsukagoshi'
     target-branch: 'main'
-    open-pull-requests-limit: 10
+    groups:
+      monthly-batch:
+        patterns:
+          - '*'
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     cooldown:
       default-days: 7
     assignees:
       - 'ttsukagoshi'
     target-branch: 'main'
-    open-pull-requests-limit: 10
+    groups:
+      monthly-batch:
+        patterns:
+          - '*'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'monthly'
     cooldown:
       default-days: 7
     assignees:
       - 'ttsukagoshi'
     target-branch: 'main'
-    open-pull-requests-limit: 10
+    groups:
+      monthly-batch:
+        patterns:
+          - '*'


### PR DESCRIPTION
https://github.com/akita-international-university/strategic-planning/issues/333 関連
See: [Tame Dependabot: Group your updates, slow the cadence, keep security fast - The GitHub Blog](https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/)

---

This pull request updates the Dependabot configuration to reduce the frequency of update checks and to group dependency updates together for easier management.

**Dependabot schedule and grouping updates:**

* Changed the update interval for `pip`, `npm`, and `github-actions` dependencies from weekly to monthly.
* Removed the `open-pull-requests-limit` setting and added a `groups` configuration to batch all updates into a single monthly pull request for each ecosystem.